### PR TITLE
limit concurrency to 1 for no-parallelism transfers (SOFTWARE-1495)

### DIFF
--- a/src/gridftp_hdfs_recv.c
+++ b/src/gridftp_hdfs_recv.c
@@ -451,6 +451,9 @@ hdfs_dispatch_write(
 */
     globus_gridftp_server_get_optimal_concurrency(hdfs_handle->op,
                                                   &hdfs_handle->optimal_count);
+    if (hdfs_handle->optimal_count == 2) {
+        hdfs_handle->optimal_count = 1;
+    }
     globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, 
         "hdfs_dispatch_write; outstanding %d, optimal %d.\n",
         hdfs_handle->outstanding, hdfs_handle->optimal_count);


### PR DESCRIPTION
Forcing gridftp-hdfs to limit the in-flight transfers to 1 prevents the
out-of-sequence corruptions seen in SOFTWARE-1495.

This also works around the issue mentioned in the ticket, where
globus-url-copy would always hang after the tranfer completed.

This corresponds to 1495-optimal-concurrency.patch used in osg.
